### PR TITLE
[mistos][pr] Fix circleci cache scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - run:
           name: Build
           command: |
-            make kasan args gen
+            make args gen
             NOECHO= make kernel_unit_test
       - run:
           name: Test


### PR DESCRIPTION
- Fix circleci to build when a new cache is generated (or no cache at all)
- Remove ksan from regular builds (to be re-enabled when circleci branch filter is in place)